### PR TITLE
feat: add repository layer for db operations

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,0 +1,9 @@
+__pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+venv/
+.env
+.mypy_cache/
+.ruff_cache/
+.pytest_cache/

--- a/backend/.ruff.toml
+++ b/backend/.ruff.toml
@@ -1,0 +1,2 @@
+line-length = 88
+src = ["app", "tests"]

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,21 @@
+# Smart Screener Backend
+
+Minimal FastAPI backend scaffold for an AI-powered Indian stock screener.
+
+## Running the server
+
+From within `backend/`:
+
+```bash
+python -m uvicorn app.main:app --reload
+```
+
+Visit `http://127.0.0.1:8000/health` to verify the service is running.
+
+## Testing
+
+Run the test suite with:
+
+```bash
+pytest
+```

--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -1,0 +1,35 @@
+[alembic]
+script_location = alembic
+sqlalchemy.url = sqlite:///./app.db
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from logging.config import fileConfig
+
+from sqlalchemy import engine_from_config, pool
+from alembic import context
+
+from app.db.base import Base
+
+config = context.config
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+target_metadata = Base.metadata
+
+
+def run_migrations_offline() -> None:
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(url=url, target_metadata=target_metadata, literal_binds=True)
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section, {}),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/backend/alembic/versions/0001_init.py
+++ b/backend/alembic/versions/0001_init.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0001_init"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "instruments",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("symbol", sa.String(), nullable=False, unique=True),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column(
+            "instrument_type",
+            sa.Enum("stock", "etf", name="instrument_type"),
+            nullable=False,
+        ),
+        sa.Column("sector", sa.String(), nullable=True),
+        sa.Column("market_cap", sa.Float(), nullable=True),
+        sa.Column("exchange", sa.String(), nullable=False, server_default="NSE"),
+    )
+    op.create_table(
+        "metrics",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column(
+            "instrument_id",
+            sa.Integer(),
+            sa.ForeignKey("instruments.id"),
+            nullable=False,
+        ),
+        sa.Column("as_of_date", sa.Date(), nullable=False),
+        sa.Column("price", sa.Float(), nullable=False),
+        sa.Column("pe", sa.Float(), nullable=True),
+        sa.Column("roe", sa.Float(), nullable=True),
+        sa.Column("debt_to_equity", sa.Float(), nullable=True),
+        sa.Column("dividend_yield", sa.Float(), nullable=True),
+        sa.Column("revenue_growth", sa.Float(), nullable=True),
+        sa.Column("earnings_growth", sa.Float(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("metrics")
+    op.drop_table("instruments")

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,0 +1,5 @@
+"""Backend application package."""
+
+__all__ = ["__version__"]
+
+__version__ = "0.1.0"

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,0 +1,22 @@
+from functools import lru_cache
+from typing import Literal
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    """Application configuration."""
+
+    APP_ENV: str = "development"
+    LOG_LEVEL: str = "INFO"
+    DATABASE_URL: str = "sqlite:///:memory:"
+    AI_PROVIDER: Literal["mock", "openai"] = "mock"
+    AI_API_KEY: str | None = None
+
+    model_config = SettingsConfigDict(env_file=".env", case_sensitive=True)
+
+
+@lru_cache
+def get_settings() -> Settings:
+    """Return cached application settings."""
+    return Settings()

--- a/backend/app/db/__init__.py
+++ b/backend/app/db/__init__.py
@@ -1,0 +1,1 @@
+"""Database utilities and models."""

--- a/backend/app/db/base.py
+++ b/backend/app/db/base.py
@@ -1,0 +1,7 @@
+from sqlalchemy.orm import DeclarativeBase
+
+
+class Base(DeclarativeBase):
+    """Base class for all models."""
+
+    pass

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from datetime import date
+from enum import Enum
+from typing import Optional
+
+from sqlalchemy import Date, Enum as SqlEnum, Float, ForeignKey, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from .base import Base
+
+
+class InstrumentType(str, Enum):
+    STOCK = "stock"
+    ETF = "etf"
+
+
+class Instrument(Base):
+    __tablename__ = "instruments"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    symbol: Mapped[str] = mapped_column(String, unique=True, nullable=False)
+    name: Mapped[str] = mapped_column(String, nullable=False)
+    instrument_type: Mapped[InstrumentType] = mapped_column(
+        SqlEnum(InstrumentType), nullable=False
+    )
+    sector: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    market_cap: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
+    exchange: Mapped[str] = mapped_column(String, nullable=False, default="NSE")
+
+    metrics: Mapped[list["Metric"]] = relationship(back_populates="instrument")
+
+
+class Metric(Base):
+    __tablename__ = "metrics"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    instrument_id: Mapped[int] = mapped_column(ForeignKey("instruments.id"), nullable=False)
+    as_of_date: Mapped[date] = mapped_column(Date, nullable=False)
+    price: Mapped[float] = mapped_column(Float, nullable=False)
+    pe: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
+    roe: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
+    debt_to_equity: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
+    dividend_yield: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
+    revenue_growth: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
+    earnings_growth: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
+
+    instrument: Mapped[Instrument] = relationship(back_populates="metrics")

--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -1,0 +1,12 @@
+from sqlalchemy import Engine, create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+
+def get_engine(url: str) -> Engine:
+    """Create a database engine for the given URL."""
+    return create_engine(url, future=True)
+
+
+def get_session(engine: Engine) -> Session:
+    """Create a new session bound to the provided engine."""
+    return sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,26 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+import logging
+
+from app.core.config import get_settings
+
+
+class HealthResponse(BaseModel):
+    status: str
+
+
+app = FastAPI()
+logger = logging.getLogger(__name__)
+
+
+@app.on_event("startup")
+async def startup() -> None:
+    settings = get_settings()
+    logger.setLevel(settings.LOG_LEVEL)
+    logger.info("APP_ENV=%s LOG_LEVEL=%s", settings.APP_ENV, settings.LOG_LEVEL)
+
+
+@app.get("/health", response_model=HealthResponse)
+async def health() -> HealthResponse:
+    """Return service health status."""
+    return HealthResponse(status="ok")

--- a/backend/app/repositories/instruments.py
+++ b/backend/app/repositories/instruments.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.db.models import Instrument
+
+
+class InstrumentRepository:
+    """Repository for CRUD operations on Instrument entities."""
+
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    def create(self, instrument: Instrument) -> Instrument:
+        """Insert a new instrument."""
+        self._session.add(instrument)
+        self._session.commit()
+        self._session.refresh(instrument)
+        return instrument
+
+    def get_by_symbol(self, symbol: str) -> Instrument | None:
+        """Retrieve an instrument by its symbol."""
+        return (
+            self._session.query(Instrument)
+            .filter(Instrument.symbol == symbol)
+            .first()
+        )
+
+    def list_all(self) -> list[Instrument]:
+        """Return all instruments."""
+        return self._session.query(Instrument).all()
+
+    def upsert_by_symbol(self, instrument: Instrument) -> Instrument:
+        """Create or update an instrument based on its symbol."""
+        existing = self.get_by_symbol(instrument.symbol)
+        if existing is not None:
+            existing.name = instrument.name
+            existing.instrument_type = instrument.instrument_type
+            existing.sector = instrument.sector
+            existing.market_cap = instrument.market_cap
+            existing.exchange = instrument.exchange
+            self._session.commit()
+            self._session.refresh(existing)
+            return existing
+        return self.create(instrument)

--- a/backend/app/repositories/metrics.py
+++ b/backend/app/repositories/metrics.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.db.models import Instrument, Metric
+
+
+class MetricRepository:
+    """Repository for operations on Metric entities."""
+
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    def create(self, metric: Metric) -> Metric:
+        """Insert a new metric record."""
+        self._session.add(metric)
+        self._session.commit()
+        self._session.refresh(metric)
+        return metric
+
+    def list_by_instrument(self, symbol: str) -> list[Metric]:
+        """List metrics for a given instrument symbol ordered by date."""
+        return (
+            self._session.query(Metric)
+            .join(Instrument)
+            .filter(Instrument.symbol == symbol)
+            .order_by(Metric.as_of_date)
+            .all()
+        )
+
+    def latest_by_instrument(self, symbol: str) -> Metric | None:
+        """Return the most recent metric for an instrument symbol."""
+        return (
+            self._session.query(Metric)
+            .join(Instrument)
+            .filter(Instrument.symbol == symbol)
+            .order_by(Metric.as_of_date.desc())
+            .first()
+        )

--- a/backend/mypy.ini
+++ b/backend/mypy.ini
@@ -1,0 +1,3 @@
+[mypy]
+python_version = 3.11
+strict = True

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,0 +1,32 @@
+[project]
+name = "smart-screener-backend"
+version = "0.1.0"
+description = "AI-powered Indian stock screener backend"
+requires-python = ">=3.11"
+dependencies = [
+  "fastapi",
+  "uvicorn[standard]",
+  "pydantic",
+  "pydantic-settings",
+  "pytest",
+  "httpx",
+  "ruff",
+  "black",
+  "isort",
+  "mypy",
+  "sqlalchemy",
+  "alembic",
+  "psycopg[binary]",
+]
+
+[tool.black]
+line-length = 88
+
+[tool.isort]
+profile = "black"
+
+[tool.ruff]
+line-length = 88
+
+[tool.mypy]
+strict = true

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -1,0 +1,35 @@
+from app.core.config import get_settings
+
+
+def _clear_cache() -> None:
+    get_settings.cache_clear()  # type: ignore[attr-defined]
+
+
+def test_settings_defaults(monkeypatch) -> None:
+    monkeypatch.delenv("APP_ENV", raising=False)
+    monkeypatch.delenv("LOG_LEVEL", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("AI_PROVIDER", raising=False)
+    monkeypatch.delenv("AI_API_KEY", raising=False)
+    _clear_cache()
+    settings = get_settings()
+    assert settings.APP_ENV == "development"
+    assert settings.LOG_LEVEL == "INFO"
+    assert settings.DATABASE_URL == "sqlite:///:memory:"
+    assert settings.AI_PROVIDER == "mock"
+    assert settings.AI_API_KEY is None
+
+
+def test_settings_env_overrides(monkeypatch) -> None:
+    monkeypatch.setenv("APP_ENV", "production")
+    monkeypatch.setenv("LOG_LEVEL", "DEBUG")
+    monkeypatch.setenv("DATABASE_URL", "postgresql://db")
+    monkeypatch.setenv("AI_PROVIDER", "openai")
+    monkeypatch.setenv("AI_API_KEY", "token")
+    _clear_cache()
+    settings = get_settings()
+    assert settings.APP_ENV == "production"
+    assert settings.LOG_LEVEL == "DEBUG"
+    assert settings.DATABASE_URL == "postgresql://db"
+    assert settings.AI_PROVIDER == "openai"
+    assert settings.AI_API_KEY == "token"

--- a/backend/tests/test_db_models.py
+++ b/backend/tests/test_db_models.py
@@ -1,0 +1,28 @@
+from datetime import date
+
+from app.db.base import Base
+from app.db.models import Instrument, InstrumentType, Metric
+from app.db.session import get_engine, get_session
+
+
+def test_insert_instrument_and_metric() -> None:
+    engine = get_engine("sqlite:///:memory:")
+    Base.metadata.create_all(bind=engine)
+    session = get_session(engine)
+
+    instrument = Instrument(symbol="INFY", name="Infosys", instrument_type=InstrumentType.STOCK)
+    session.add(instrument)
+    session.commit()
+    session.refresh(instrument)
+
+    metric = Metric(
+        instrument_id=instrument.id,
+        as_of_date=date(2024, 1, 1),
+        price=100.0,
+    )
+    session.add(metric)
+    session.commit()
+
+    result = session.query(Metric).filter_by(instrument_id=instrument.id).one()
+    assert result.price == 100.0
+    assert result.instrument_id == instrument.id

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -1,0 +1,10 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+def test_health() -> None:
+    client = TestClient(app)
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}

--- a/backend/tests/test_repositories.py
+++ b/backend/tests/test_repositories.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from datetime import date
+
+from app.db.base import Base
+from app.db.models import Instrument, InstrumentType, Metric
+from app.db.session import get_engine, get_session
+from app.repositories.instruments import InstrumentRepository
+from app.repositories.metrics import MetricRepository
+
+
+def test_repositories_work() -> None:
+    engine = get_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    session = get_session(engine)
+
+    instrument_repo = InstrumentRepository(session)
+    metric_repo = MetricRepository(session)
+
+    inst = Instrument(
+        symbol="TCS",
+        name="Tata Consultancy",
+        instrument_type=InstrumentType.STOCK,
+        exchange="NSE",
+    )
+    created = instrument_repo.create(inst)
+
+    # upsert by symbol updates existing record
+    instrument_repo.upsert_by_symbol(
+        Instrument(
+            symbol="TCS",
+            name="TCS Ltd",
+            instrument_type=InstrumentType.STOCK,
+            exchange="NSE",
+        )
+    )
+    fetched = instrument_repo.get_by_symbol("TCS")
+    assert fetched is not None
+    assert fetched.name == "TCS Ltd"
+    assert len(instrument_repo.list_all()) == 1
+
+    metric_repo.create(
+        Metric(
+            instrument_id=created.id,
+            as_of_date=date(2023, 1, 1),
+            price=100.0,
+        )
+    )
+    metric_repo.create(
+        Metric(
+            instrument_id=created.id,
+            as_of_date=date(2023, 1, 2),
+            price=110.0,
+        )
+    )
+
+    metrics = metric_repo.list_by_instrument("TCS")
+    assert len(metrics) == 2
+    latest = metric_repo.latest_by_instrument("TCS")
+    assert latest is not None
+    assert latest.price == 110.0


### PR DESCRIPTION
## Summary
- add instrument repository with CRUD and upsert methods
- add metric repository with create and lookup helpers
- cover repository behaviors with in-memory sqlite tests

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi'; No module named 'app')*


------
https://chatgpt.com/codex/tasks/task_e_68b4565a075c832aae67dea6653ec85f